### PR TITLE
Read Telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # For personal use
 ignore/
+
+# Editor settings
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 **/.DS_Store
+
+# For personal use
+ignore/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - 2022-10-27
+- Add all source files into container on startup
+- Add basic telemetry functions
+- Update Dockerfile to benefit from caching
+- See PR: https://github.com/sf314/krpc-fsw/pull/2

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,8 @@ RUN apt-get install -y libprotobuf-dev protobuf-compiler
 # Install packages required to build and install KRPC
 RUN apt-get install -y pkg-config unzip gcc g++ make cmake
 
-# Copy over all source files and build scripts
+# Copy over dependencies, which should be built first, so it gets cached
 COPY deps /krpc-fsw/deps
-COPY fsw.mak /krpc-fsw/Makefile
-COPY src /krpc-fsw/src
-COPY include /krpc-fsw/include
 
 # Unzip, build, and install KRPC (requires pkg-config)
 # Download link (working fork): https://github.com/nullprofile/krpc/releases/tag/0.4.9-1.12.1
@@ -29,6 +26,11 @@ RUN cd /krpc-fsw/krpc-cpp-0.4.9 \
     && make \
     && make install \
     && ldconfig
+
+# Copy over FSW. They are loaded last because they are expected to change the most
+COPY fsw.mak /krpc-fsw/Makefile
+COPY src /krpc-fsw/src
+COPY include /krpc-fsw/include
 
 # Build and run the source code using the FSW makefile (Makefile.fsw)
 RUN make

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y pkg-config unzip gcc g++ make cmake
 
 # Copy over all source files and build scripts
 COPY deps /krpc-fsw/deps
-COPY Makefile.fsw /krpc-fsw/Makefile
+COPY fsw.mak /krpc-fsw/Makefile
 COPY main.cpp /krpc-fsw/main.cpp
 
 # Unzip, build, and install KRPC (requires pkg-config)

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get install -y pkg-config unzip gcc g++ make cmake
 # Copy over all source files and build scripts
 COPY deps /krpc-fsw/deps
 COPY fsw.mak /krpc-fsw/Makefile
-COPY main.cpp /krpc-fsw/main.cpp
+COPY src /krpc-fsw/src
+COPY include /krpc-fsw/include
 
 # Unzip, build, and install KRPC (requires pkg-config)
 # Download link (working fork): https://github.com/nullprofile/krpc/releases/tag/0.4.9-1.12.1

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ all:
 no-cache:
 	docker build . --no-cache
 
-# Start the FSW in a container using the latest built image.
+# Start the FSW in a container using the latest built image. (not docker-compose up)
 run:
-	docker-compose up
+	docker run krpc_krpc-fsw
 
 # Remove all stopped containers, and delete the FSW image by name.
 # Note: this prunes *all* stopped containers, including containers for other

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DOCKER_IMAGE_NAME := krpc_krpc-fsw
 # Note: Uncomment VERBOSE_FLAG for more logs, this is helpful for debugging
 # any compilation errors.
 all:
-	docker build . $(VERBOSE_FLAG)
+	docker build . $(VERBOSE_FLAG) -t $(DOCKER_IMAGE_NAME)
 
 # Build a fresh image as defined by the provided Dockerfile, but do not use any
 # cached intermediate containers. This results in the freshest build.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KRPC Main Code Repo
+# KRPC Flight Software
 
 This project will hold all code related to controlling ships in KSP via a
 KRPC client running within a Docker container.
@@ -29,6 +29,10 @@ To list all the `make` options I provide, use:
 ```sh
 make help
 ```
+
+Note that `Makefile` is for Docker operations, and `fsw.mak` is for actually
+building the FSW. If you don't care about Docker, and have all the dependencies
+installed locally, then you may simply use `fsw.make` as your main Makefile.
 
 ## What is KRPC?
 
@@ -66,7 +70,7 @@ Links:
 
 The official release of KRPC is 0.4.8, found in the [official KRPC repo](https://github.com/krpc/krpc/releases).
 However, this code does not compile against the current version of ASIO
-(libasi-dev), because of a few recent API changes. This means there is not an
+(libasio-dev), because of a few recent API changes. This means there is not an
 official build of KRPC that can successfully compile.
 
 The solution has been found in a fork: [`nullprofile/krpc` version 0.4.9](https://github.com/nullprofile/krpc/releases/tag/0.4.9-1.12.1).

--- a/fsw.mak
+++ b/fsw.mak
@@ -7,8 +7,11 @@
 
 .PHONY: all run
 
+INCLUDES = \
+	-Iinclude
+
 SOURCES = \
-	main.cpp
+	src/main.cpp
 
 FLAGS = \
 	-std=c++11 \

--- a/fsw.mak
+++ b/fsw.mak
@@ -11,7 +11,8 @@ INCLUDES = \
 	-Iinclude
 
 SOURCES = \
-	src/main.cpp
+	src/main.cpp \
+	src/telemetry.cpp
 
 FLAGS = \
 	-std=c++11 \
@@ -25,7 +26,7 @@ LIBS = \
 EXEC = krpc-fsw
 
 all:
-	g++ $(FLAGS) $(SOURCES) -o $(EXEC) $(LIBS)
+	g++ $(FLAGS) $(INCLUDES) $(SOURCES) -o $(EXEC) $(LIBS)
 
 run:
 	./$(EXEC)

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -48,5 +48,28 @@ typedef struct {
 
 } telemetry_t;
 
+/**
+ * @brief Update the provided telemetry struct based on the current data from
+ * the provided vessel.
+ * 
+ * @param vessel KRPC Vessel
+ * @param telem Telemetry struct
+ */
+void update_telemetry(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* telem);
+
+/**
+ * @brief Print the provided telemetry all at once
+ * 
+ * @param telem Telemetry struct
+ */
+void print_telemetry(telemetry_t* telem);
+
+/**
+ * @brief Based on the provided telemetry, print any potential warnings, i.e.
+ * GPWS, G-Force, TCAS, etc.
+ * 
+ * @param telem Telemetry struct
+ */
+void print_warnings(telemetry_t* telem);
 
 #endif

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -55,14 +55,14 @@ typedef struct {
  * @param vessel KRPC Vessel
  * @param telem Telemetry struct
  */
-void update_telemetry(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* telem);
+void telemetry_update(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* telem);
 
 /**
  * @brief Print the provided telemetry all at once
  * 
  * @param telem Telemetry struct
  */
-void print_telemetry(telemetry_t* telem);
+void telemetry_display(telemetry_t* telem);
 
 /**
  * @brief Based on the provided telemetry, print any potential warnings, i.e.
@@ -70,6 +70,6 @@ void print_telemetry(telemetry_t* telem);
  * 
  * @param telem Telemetry struct
  */
-void print_warnings(telemetry_t* telem);
+void telemetry_warnings(telemetry_t* telem);
 
 #endif

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -2,6 +2,11 @@
 
 #define _TELEMETRY_H
 
+// KRPC
+#include <krpc.hpp>
+#include <krpc/services/krpc.hpp>
+#include <krpc/services/space_center.hpp>
+
 typedef struct {
     // Position data
     double alt_mean; // ASL

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -1,0 +1,34 @@
+#ifndef _TELEMETRY_H
+
+#define _TELEMETRY_H
+
+typedef struct {
+    // Position data
+    double alt_mean; // ASL
+    double alt_surf; // AGL
+    double lat; // GPS N<->S, (-90,90)
+    double lon; // GPS E<->W, (-180, 180)
+
+    // Orientation data
+    double dir_x; // Note: take from vessel in surface reference frame
+    double dir_y;
+    double dir_z;
+    double pitch; // Note: take from vessel in vessel reference frame
+    double heading;
+    double roll;
+
+    // Motion data
+    double speed;
+    double speed_mach;
+    double speed_h;
+    double speed_v;
+
+    // Forces
+    float g_force;
+    float thrust;
+    float thrust_avail;
+
+} telemetry_t;
+
+
+#endif

--- a/include/telemetry.h
+++ b/include/telemetry.h
@@ -28,6 +28,19 @@ typedef struct {
     float thrust;
     float thrust_avail;
 
+    // TODO:
+    // Thrust per engine
+    // Gear status (up/down)
+    // Light status
+    // Aileron pitch
+    // Elevator pitch
+    // Rudder angle
+    // Flaps status
+    // Indicated airspeed
+    // Ambient pressure
+    // Mass
+    // Drag (vector?)
+
 } telemetry_t;
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,0 @@
-#include <iostream>
-#include <krpc.hpp>
-#include <krpc/services/krpc.hpp>
-
-int main() {
-  auto conn = krpc::connect();
-  krpc::services::KRPC krpc(&conn);
-  std::cout << "Connected to kRPC server version " << krpc.get_status().version() << std::endl;
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,17 @@
 #include <iostream>
+
+#include <signal.h>
+
 #include <krpc.hpp>
 #include <krpc/services/krpc.hpp>
 #include <krpc/services/space_center.hpp>
 
+krpc::Client conn;
+
 int main() {
-    auto conn = krpc::connect();
+
+    std::cout << "Starting KRPC session..." << std::endl;
+    conn = krpc::connect("MBP", "10.0.1.205", 50002U, 50003U);
     krpc::services::KRPC krpc(&conn);
     std::cout << "Connected to kRPC server version " << krpc.get_status().version() << std::endl;
     // printf("Connected to kRPC server version %s\n", krpc.get_status().version().c_str());
@@ -12,11 +19,72 @@ int main() {
     // Get vessel info from Space Center
     krpc::services::SpaceCenter spaceCenter(&conn);
     auto vessel = spaceCenter.active_vessel();
-    auto flight_info = vessel.flight();
+    auto frame_srf = vessel.orbit().body().reference_frame();
+    auto frame_vsl = vessel.surface_reference_frame();
+    auto flight_info = vessel.flight(frame_vsl); // FOR EVERYTHING ELSE
+    auto flight_info_srf = vessel.flight(frame_srf); // FOR SPEED/VELOCITY
 
     // Printout snapshot of flight telem
-    std::cout << "Mean altitude: " << flight_info.mean_altitude() << std::endl;
-    std::cout << "G-force: " << flight_info.g_force() << std::endl;
-    std::cout << "Lat: " << flight_info.latitude() << std::endl;
-    std::cout << "Lon: " << flight_info.longitude() << std::endl;
+    while (1) {
+        // Gather data
+        double alt_mean = flight_info.mean_altitude();
+        double alt_surf = flight_info.surface_altitude();
+
+        double lat = flight_info.latitude();
+        double lon = flight_info.longitude();
+
+        float g_force = flight_info.g_force();
+
+        float thrust = vessel.thrust();
+        float thrust_avail = vessel.available_thrust();
+
+        double dir_x = std::get<0>(vessel.direction(vessel.surface_reference_frame()));
+        double dir_y = std::get<1>(vessel.direction(vessel.surface_reference_frame()));
+        double dir_z = std::get<2>(vessel.direction(vessel.surface_reference_frame()));
+
+        double speed = flight_info_srf.speed();
+        double speed_mach = flight_info_srf.mach();
+        double speed_h = flight_info_srf.horizontal_speed();
+        double speed_v = flight_info_srf.vertical_speed();
+
+        float pitch = flight_info.pitch();
+        float heading = flight_info.heading();
+        float roll = flight_info.roll();
+
+        // Print data, all at once (so there's not perceptible RPC lag)
+        
+        std::cout << "GPS lat: " << lat << std::endl;
+        std::cout << "    lon: " << lon << std::endl;
+        std::cout << "G-force: " << g_force << std::endl;
+        std::cout << "Thrust currn: " << thrust << std::endl;
+        std::cout << "       avail: " << thrust_avail << std::endl;
+        std::cout << "Dir x: " << dir_x << std::endl;
+        std::cout << "    y: " << dir_y << std::endl;
+        std::cout << "    z: " << dir_z << std::endl;
+
+        std::cout << "Alt mean: " << alt_mean << std::endl;
+        std::cout << "    surf: " << alt_surf << std::endl;
+        std::cout << "Speed: " << speed << " (mach " << speed_mach << ")" << std::endl;
+        std::cout << "    h: " << speed_h << std::endl;
+        std::cout << "    v: " << speed_v << std::endl;
+        std::cout << "Pitch: " << pitch << std::endl;
+        std::cout << "Roll: " << roll << std::endl;
+        std::cout << "Heading: " << heading << std::endl;
+
+
+        // Print warnings based on data
+        if (speed_v < 0.0 && alt_surf < 1000.0 && speed_h > 150) {
+            std::cout << "WARNING: GROUND PROXIMITY" << "\a" << std::endl;
+        }
+
+        if (g_force > 2.0) {
+            std::cout << "WARNING: HIGH-G" << "\a" << std::endl;
+        }
+
+        if (g_force < 0.5) {
+            std::cout << "WARNING: LOW-G" << "\a" << std::endl;
+        }
+
+        std::cout <<  "----------" << std::endl;
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,22 @@
 #include <iostream>
 #include <krpc.hpp>
 #include <krpc/services/krpc.hpp>
+#include <krpc/services/space_center.hpp>
 
 int main() {
     auto conn = krpc::connect();
     krpc::services::KRPC krpc(&conn);
     std::cout << "Connected to kRPC server version " << krpc.get_status().version() << std::endl;
+    // printf("Connected to kRPC server version %s\n", krpc.get_status().version().c_str());
+
+    // Get vessel info from Space Center
+    krpc::services::SpaceCenter spaceCenter(&conn);
+    auto vessel = spaceCenter.active_vessel();
+    auto flight_info = vessel.flight();
+
+    // Printout snapshot of flight telem
+    std::cout << "Mean altitude: " << flight_info.mean_altitude() << std::endl;
+    std::cout << "G-force: " << flight_info.g_force() << std::endl;
+    std::cout << "Lat: " << flight_info.latitude() << std::endl;
+    std::cout << "Lon: " << flight_info.longitude() << std::endl;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+#include <krpc.hpp>
+#include <krpc/services/krpc.hpp>
+
+int main() {
+    auto conn = krpc::connect();
+    krpc::services::KRPC krpc(&conn);
+    std::cout << "Connected to kRPC server version " << krpc.get_status().version() << std::endl;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include <signal.h>
+#include <telemetry.h>
 
 #include <krpc.hpp>
 #include <krpc/services/krpc.hpp>
@@ -14,7 +14,6 @@ int main() {
     conn = krpc::connect("MBP", "10.0.1.205", 50002U, 50003U);
     krpc::services::KRPC krpc(&conn);
     std::cout << "Connected to kRPC server version " << krpc.get_status().version() << std::endl;
-    // printf("Connected to kRPC server version %s\n", krpc.get_status().version().c_str());
 
     // Get vessel info from Space Center
     krpc::services::SpaceCenter spaceCenter(&conn);
@@ -25,66 +24,11 @@ int main() {
     auto flight_info_srf = vessel.flight(frame_srf); // FOR SPEED/VELOCITY
 
     // Printout snapshot of flight telem
+    telemetry_t telem;
     while (1) {
-        // Gather data
-        double alt_mean = flight_info.mean_altitude();
-        double alt_surf = flight_info.surface_altitude();
-
-        double lat = flight_info.latitude();
-        double lon = flight_info.longitude();
-
-        float g_force = flight_info.g_force();
-
-        float thrust = vessel.thrust();
-        float thrust_avail = vessel.available_thrust();
-
-        double dir_x = std::get<0>(vessel.direction(vessel.surface_reference_frame()));
-        double dir_y = std::get<1>(vessel.direction(vessel.surface_reference_frame()));
-        double dir_z = std::get<2>(vessel.direction(vessel.surface_reference_frame()));
-
-        double speed = flight_info_srf.speed();
-        double speed_mach = flight_info_srf.mach();
-        double speed_h = flight_info_srf.horizontal_speed();
-        double speed_v = flight_info_srf.vertical_speed();
-
-        float pitch = flight_info.pitch();
-        float heading = flight_info.heading();
-        float roll = flight_info.roll();
-
-        // Print data, all at once (so there's not perceptible RPC lag)
-        
-        std::cout << "GPS lat: " << lat << std::endl;
-        std::cout << "    lon: " << lon << std::endl;
-        std::cout << "G-force: " << g_force << std::endl;
-        std::cout << "Thrust currn: " << thrust << std::endl;
-        std::cout << "       avail: " << thrust_avail << std::endl;
-        std::cout << "Dir x: " << dir_x << std::endl;
-        std::cout << "    y: " << dir_y << std::endl;
-        std::cout << "    z: " << dir_z << std::endl;
-
-        std::cout << "Alt mean: " << alt_mean << std::endl;
-        std::cout << "    surf: " << alt_surf << std::endl;
-        std::cout << "Speed: " << speed << " (mach " << speed_mach << ")" << std::endl;
-        std::cout << "    h: " << speed_h << std::endl;
-        std::cout << "    v: " << speed_v << std::endl;
-        std::cout << "Pitch: " << pitch << std::endl;
-        std::cout << "Roll: " << roll << std::endl;
-        std::cout << "Heading: " << heading << std::endl;
-
-
-        // Print warnings based on data
-        if (speed_v < 0.0 && alt_surf < 1000.0 && speed_h > 150) {
-            std::cout << "WARNING: GROUND PROXIMITY" << "\a" << std::endl;
-        }
-
-        if (g_force > 2.0) {
-            std::cout << "WARNING: HIGH-G" << "\a" << std::endl;
-        }
-
-        if (g_force < 0.5) {
-            std::cout << "WARNING: LOW-G" << "\a" << std::endl;
-        }
-
+        telemetry_update(vessel, &telem);
+        telemetry_display(&telem);
+        telemetry_warnings(&telem);
         std::cout <<  "----------" << std::endl;
     }
 }

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -1,0 +1,82 @@
+#include <telemetry.h>
+
+// KRPC
+#include <krpc.hpp>
+#include <krpc/services/krpc.hpp>
+#include <krpc/services/space_center.hpp>
+
+void update_telemetry(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* telem) {
+    using namespace std;
+
+    // Reference frames
+    auto frame_srf = vessel.orbit().body().reference_frame();
+    auto frame_vsl = vessel.surface_reference_frame();
+
+    // Flight information objs
+    auto flight_info = vessel.flight(frame_vsl); // FOR EVERYTHING ELSE
+    auto flight_info_srf = vessel.flight(frame_srf); // FOR SPEED/VELOCITY
+
+    // Position data
+    telem->alt_mean = flight_info.mean_altitude();
+    telem->lat = flight_info.latitude();
+    telem->lon = flight_info.longitude();
+
+    // Orientation data
+    telem->dir_x = std::get<0>(vessel.direction(vessel.surface_reference_frame()));
+    telem->dir_y = std::get<1>(vessel.direction(vessel.surface_reference_frame()));
+    telem->dir_z = std::get<2>(vessel.direction(vessel.surface_reference_frame()));
+    telem->pitch = flight_info.pitch();
+    telem->heading = flight_info.heading();
+    telem->roll = flight_info.roll();
+
+    // Motion data
+    telem->speed = flight_info_srf.speed();
+    telem->speed_mach = flight_info_srf.mach();
+    telem->speed_h = flight_info_srf.horizontal_speed();
+    telem->speed_v = flight_info_srf.vertical_speed();
+
+    // Forces
+    telem->g_force = flight_info.g_force();
+    telem->thrust = vessel.thrust();
+    telem->thrust_avail = vessel.available_thrust();
+}
+
+void print_telemetry(telemetry_t* telem) {
+    using namespace std;
+
+    // Print data, all at once (so there's not perceptible RPC lag)
+    cout << "GPS lat: " << telem->lat << endl;
+    cout << "    lon: " << telem->lon << endl;
+    cout << "G-force: " << telem->g_force << endl;
+    cout << "Thrust currn: " << telem->thrust << endl;
+    cout << "       avail: " << telem->thrust_avail << endl;
+    cout << "Dir x: " << telem->dir_x << endl;
+    cout << "    y: " << telem->dir_y << endl;
+    cout << "    z: " << telem->dir_z << endl;
+
+    cout << "Alt mean: " << telem->alt_mean << endl;
+    cout << "    surf: " << telem->alt_surf << endl;
+    cout << "Speed: " << telem->speed << " (mach " << telem->speed_mach << ")" << endl;
+    cout << "    h: " << telem->speed_h << endl;
+    cout << "    v: " << telem->speed_v << endl;
+    cout << "Pitch: " << telem->pitch << endl;
+    cout << "Roll: " << telem->roll << endl;
+    cout << "Heading: " << telem->heading << endl;
+}
+
+void print_warnings(telemetry_t* telem) {
+    using namespace std;
+
+    // Print warnings based on data
+    if (telem->speed_v < 0.0 && telem->alt_surf < 1000.0 && telem->speed_h > 150) {
+        cout << "WARNING: GROUND PROXIMITY" << "\a" << endl;
+    }
+
+    if (telem->g_force > 2.0) {
+        cout << "WARNING: HIGH-G" << "\a" << endl;
+    }
+
+    if (telem->g_force < 0.5) {
+        cout << "WARNING: LOW-G" << "\a" << endl;
+    }
+}

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -5,7 +5,7 @@
 #include <krpc/services/krpc.hpp>
 #include <krpc/services/space_center.hpp>
 
-void update_telemetry(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* telem) {
+void telemetry_update(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* telem) {
     using namespace std;
 
     // Reference frames
@@ -41,7 +41,7 @@ void update_telemetry(krpc::services::SpaceCenter::Vessel vessel, telemetry_t* t
     telem->thrust_avail = vessel.available_thrust();
 }
 
-void print_telemetry(telemetry_t* telem) {
+void telemetry_display(telemetry_t* telem) {
     using namespace std;
 
     // Print data, all at once (so there's not perceptible RPC lag)
@@ -64,7 +64,7 @@ void print_telemetry(telemetry_t* telem) {
     cout << "Heading: " << telem->heading << endl;
 }
 
-void print_warnings(telemetry_t* telem) {
+void telemetry_warnings(telemetry_t* telem) {
     using namespace std;
 
     // Print warnings based on data


### PR DESCRIPTION
# Read Telemetry 

These commits enable the FSW to connect to a KRPC server, and continuously read some basic telemetry from the vessel.

Interface:
```c
telemetry_update(vessel, &telem);
telemetry_display(&telem);
telemetry_warnings(&telem);
```

Telemetry:
```c
// Position data
double alt_mean; // ASL
double alt_surf; // AGL
double lat; // GPS N<->S, (-90,90)
double lon; // GPS E<->W, (-180, 180)

// Orientation data
double dir_x; // Note: take from vessel in surface reference frame
double dir_y;
double dir_z;
double pitch; // Note: take from vessel in vessel reference frame
double heading;
double roll;

// Motion data
double speed;
double speed_mach;
double speed_h;
double speed_v;

// Forces
float g_force;
float thrust;
float thrust_avail;
```